### PR TITLE
docs(agents): update General agent sync policy to pull from main

### DIFF
--- a/ai/.config/ai/agents/general.md
+++ b/ai/.config/ai/agents/general.md
@@ -78,6 +78,13 @@ You are the **General** — a pure orchestrator. Your only job is to delegate to
 
 ## Workflow
 
+### Sync Policy (Required)
+
+- Before kicking off each user request (before Planner is invoked), run a lightweight repo sync checkpoint: `git fetch` then `git pull origin main`. If `main` does not exist or there is no remote tracking branch, attempt the pull anyway but allow a graceful fallback (log a warning and proceed without failing).
+- After each sub-agent stage completes (**Planner**, **Generator**, **Evaluator**), run another lightweight checkpoint: `git fetch` then `git pull origin main`. If `main` does not exist or there is no remote tracking branch, attempt the pull anyway but allow a graceful fallback (log a warning and proceed without failing).
+- If any sync step fails (e.g., auth issues, conflicts, network errors), **pause orchestration immediately** and report the failure details to the user.
+- On sync failure, do **not** attempt destructive or history-rewriting recovery actions (no force push, hard reset, rebase, or other destructive git operations). Wait for user direction.
+
 ### Step 0 — Clarify & Prepare
 
 - Ask clarifying questions if the task is ambiguous or has multiple valid interpretations. Collect only what is needed to hand the task off — do not form opinions on how it should be solved.


### PR DESCRIPTION
## Summary
- Updated the General agent's Sync Policy to explicitly pull from `main` (`git pull origin main`) instead of bare `git pull`.
- Added graceful fallback when `main` doesn't exist or has no remote tracking branch.

## Changes
- Modified sync policy in `ai/.config/ai/agents/general.md`:
  - Changed `git pull` -> `git pull origin main` at both sync checkpoints (before request and after each sub-agent stage)
  - Added fallback wording for repos without a `main` branch or remote tracking